### PR TITLE
Make the node client more tolerant towards db failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,11 @@ version: '2'
 services:
   users-service:
     build: ./users-service
+    container_name: users_service
     ports:
      - "8123:8123"
+    links:
+      - db:db
     depends_on:
      - db
     environment:

--- a/users-service/repository/repository.js
+++ b/users-service/repository/repository.js
@@ -9,8 +9,9 @@ var mysql = require('mysql');
 //  Class which holds an open connection to a repository
 //  and exposes some simple functions for accessing data.
 class Repository {
-  constructor(connection) {
-    this.connection = connection;
+  constructor(connectionSettings) {
+    this.connectionSettings = connectionSettings;
+    this.connection = mysql.createConnection(this.connectionSettings);
   }
 
   getUsers() {
@@ -18,6 +19,7 @@ class Repository {
 
       this.connection.query('SELECT email, phone_number FROM directory', (err, results) => {
         if(err) {
+          this.connection = mysql.createConnection(this.connectionSettings);
           return reject(new Error('An error occured getting the users: ' + err));
         }
 
@@ -70,6 +72,6 @@ module.exports.connect = (connectionSettings) => {
     if(!connectionSettings.password) throw new Error("A password must be specified.");
     if(!connectionSettings.port) throw new Error("A port must be specified.");
 
-    resolve(new Repository(mysql.createConnection(connectionSettings)));
+    resolve(new Repository(connectionSettings));
   });
 };


### PR DESCRIPTION
Currently the connection object is created once when the Node service starts. If the db server happens to be down during the time, all future db queries will fail. The current workaround is to delay the app service start up for 10s - 30s, depending on machines.

This approach is not desirable, as this hard coded delay needs to be replicated at a few different places in the tutorial: scripts to start docker, Dockerfile, docker-compose.yml etc. For example, see comment http://disq.us/p/1bkyocw 

Suggesting to recreate the connection object upon a connection failure. Not sure if this is the standard implementation, as I have not worked with Node.js before.
