### PR TITLE
update: update to mysql:5 from mysql:latest to avoid errors

### DIFF
--- a/test-database/start.sh
+++ b/test-database/start.sh
@@ -7,7 +7,7 @@ docker run --name db -d \
   -e MYSQL_ROOT_PASSWORD=123 \
   -e MYSQL_DATABASE=users -e MYSQL_USER=users_service -e MYSQL_PASSWORD=123 \
   -p 3306:3306 \
-  mysql:latest
+  mysql:5
 
 # Wait for the database service to start up.
 echo "Waiting for DB to start up..."


### PR DESCRIPTION
To avoid errors during server's to start up to specify mysql version by number instead of specifying as latest.